### PR TITLE
chore: Add Google Analytics

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -58,6 +58,9 @@
     "twitter": "https://twitter.com/paradedb"
   },
   "analytics": {
+    "ga4": {
+      "measurementId": "G-FETB619BM4"
+    },
     "gtm": {
       "tagId": "GTM-KMGRG564"
     }


### PR DESCRIPTION
We had it before, and I removed it to add Google Tag Manager, for Reo.dev.

Turns out we can have both, so ugh... Re-adding!